### PR TITLE
update for C++14

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: MetaStan
-Version: 0.0.1
+Version: 0.0.2
 Title: Bayesian Meta-Analysis via 'Stan'
 Description: Performs Bayesian meta-analysis using 'Stan'. 
              Includes binomial-normal hierarchical models and option to use weakly informative priors for the
@@ -11,16 +11,16 @@ Authors@R: c(person("Burak Kuersad", "Guenhan", email="burak.gunhan@med.uni-goet
              tools/make_cpp.R, R/stanmodels.R"))
 License: GPL (>=3)
 Encoding: UTF-8
-Date: 2018-08-23
+Date: 2018-10-16
 LazyData: true
 ByteCompile: true
 Depends: R (>= 3.4.0), Rcpp (>= 0.12.17), methods
-Imports: rstan (>= 2.17.3), rstantools (>= 1.5.0)
+Imports: rstan (>= 2.18.1), rstantools (>= 1.5.0)
 Suggests: testthat,
           knitr,
           rmarkdown,
           ggplot2
-LinkingTo: StanHeaders (>= 2.17.2), rstan (>= 2.17.3), BH (>= 1.66.0-1), Rcpp (>= 0.12.17), RcppEigen (>= 0.3.3.4.0)
+LinkingTo: StanHeaders (>= 2.18.0), rstan (>= 2.18.1), BH (>= 1.66.0-1), Rcpp (>= 0.12.17), RcppEigen (>= 0.3.3.4.0)
 SystemRequirements: GNU make
 NeedsCompilation: yes
 RoxygenNote: 6.1.0

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,6 +1,6 @@
 STANHEADERS_SRC = `"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" --vanilla -e "cat(system.file('include', 'src', package = 'StanHeaders'))"`
 PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_MATH_OVERFLOW_ERROR_POLICY=errno_on_error
-
+CXX_STD = CXX14
 SOURCES = $(wildcard stan_files/*.stan)
 OBJECTS = $(SOURCES:.stan=.o) init.o
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -2,7 +2,7 @@ STANHEADERS_SRC = `"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" --vanilla -e "cat(system
 BOOST_NOT_IN_BH_SRC = `"$(R_HOME)/bin$(R_ARCH_BIN)/Rscript" --vanilla -e "cat(system.file('include', 'boost_not_in_BH', package = 'rstan'))"`
 PKG_CPPFLAGS = -I"../inst/include" -I"$(STANHEADERS_SRC)" -I"$(BOOST_NOT_IN_BH_SRC)" -DBOOST_RESULT_OF_USE_TR1 -DBOOST_NO_DECLTYPE -DBOOST_DISABLE_ASSERTS -DEIGEN_NO_DEBUG -DBOOST_NO_CXX11_RVALUE_REFERENCES
 
-CXX_STD = CXX11
+CXX_STD = CXX14
 SOURCES = $(wildcard stan_files/*.stan)
 OBJECTS = $(SOURCES:.stan=.o) init.o
 


### PR DESCRIPTION
This PR allows your package to build with rstan 2.18.1 on CRAN, which requires C++14. I have run R CMD check on your package from a Debian system similar to that on CRAN and uploaded the tarball to https://win-builder.r-project.org/ so the package maintainer should soon see the result of running R CMD check on Windows. If you have questions or issues, please post at https://discourse.mc-stan.org/t/how-to-update-a-package-that-has-stanheaders-and-rstan-in-its-linkingto/6041?u=bgoodri rather than, or in addition to, this PR so that other maintainers of R packages that use Stan can benefit from your experience. If all goes well with the R CMD check, please upload a new version to CRAN soon before your package gets kicked out.



