### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,11 +18,11 @@ LazyData: true
 ByteCompile: true
 Depends: R (>= 3.5.0)
 Imports: Rcpp (>= 0.12.17), methods, 
-         rstan (>= 2.18.1), rstantools (>= 1.5.0), 
+         rstan (>= 2.26.0), rstantools (>= 1.5.0), 
          loo (>= 2.0), forestplot (>= 1.6),
          metafor (>= 2.0-0), HDInterval, coda
 Suggests: testthat, knitr, rmarkdown, ggplot2, shinystan, vdiffr, bayesmeta, metadat
-LinkingTo: StanHeaders (>= 2.18.0), rstan (>= 2.18.1), BH (>= 1.66.0-1),
+LinkingTo: StanHeaders (>= 2.26.0), rstan (>= 2.26.0), BH (>= 1.66.0-1),
           Rcpp (>= 0.12.17), RcppEigen (>= 0.3.3.4.0), RcppParallel (>= 5.0.1),
 SystemRequirements: GNU make
 NeedsCompilation: yes

--- a/inst/stan/MBMA.stan
+++ b/inst/stan/MBMA.stan
@@ -12,14 +12,14 @@ data {
   int<lower=1> Nst;
 
   // Study number for each arm
-  int<lower=1> st[Nobs];
+  array[Nobs] int<lower=1> st;
 
   // Dose amount for each arm
-  real<lower=0> dose[Nobs];
+  array[Nobs] real<lower=0> dose;
 
 
   // num doses in each trial
-  int<lower=1> ndose[Nst];
+  array[Nst] int<lower=1> ndose;
 
   // link function (1=normal, 2=binary, 3=poisson)
   int<lower=1,upper=3> link;
@@ -32,11 +32,11 @@ data {
   vector[Nobs] y_se;
 
   // binomial data, link=logit=2
-  int<lower=0>  r[Nobs];
-  int<lower=1>  n[Nobs];
+  array[Nobs] int<lower=0>  r;
+  array[Nobs] int<lower=1>  n;
 
   // count data, link=log=3
-  int<lower=0> count[Nobs];
+  array[Nobs] int<lower=0> count;
   vector[Nobs]    exposure;
 
   // Priors
@@ -53,13 +53,13 @@ data {
   int<lower=1> Npred;
 
   // Prediction points in the dose-response curve
-  real Pred_doses[Npred];
+  array[Npred] real Pred_doses;
 
   //  Indicator for placebo arm
-  int<lower=1> b_ndx[Nst];
+  array[Nst] int<lower=1> b_ndx;
 
   // Indicator for non-placebo arm
-  int<lower=1> t_ndx[Nobs-Nst];
+  array[Nobs-Nst] int<lower=1> t_ndx;
 
   // Fixed-effects or Random-effects model: (0: fe, 1: re)
   int<lower=0,upper=1> re;
@@ -101,10 +101,10 @@ transformed data{
 parameters {
   vector[Nst] mu;                             // baseline risks
   real alpha;
-  real<lower=0, upper=1.5> ED50_raw[emax];
-  real<lower=0.5, upper=10> gamma[hill];              // Hill parameter
+  array[emax] real<lower=0, upper=1.5> ED50_raw;
+  array[hill] real<lower=0.5, upper=10> gamma;              // Hill parameter
   vector[Nobs - Nst] u;
-  real<lower=0> tau[re];
+  array[re] real<lower=0> tau;
 }
 
 transformed parameters{
@@ -114,7 +114,7 @@ transformed parameters{
   vector[Nobs] md;
   vector[Nobs] delta;
   vector[Nobs] theta;
-  real<lower=0> ED50[emax];
+  array[emax] real<lower=0> ED50;
 
   // used for the prior distribution of ED50 (ED50) parameter
   if(emax == 1) {ED50[1] = ED50_raw[1] * maxdose;}
@@ -217,9 +217,9 @@ model {
 
 generated quantities {
   real mean_mu;
-  real md_pred[Npred];
-  real delta_pred[Npred];                                      // Predicted delta
-  real<lower=0, upper=1> Pred_probs[Npred];                    // Predicted probabolities
+  array[Npred] real md_pred;
+  array[Npred] real delta_pred;                                      // Predicted delta
+  array[Npred] real<lower=0, upper=1> Pred_probs;                    // Predicted probabolities
   vector[Nobs] log_lik;                                        // pointwise log-likelihood contribution
 
 

--- a/inst/stan/SMA.stan
+++ b/inst/stan/SMA.stan
@@ -13,7 +13,7 @@ data {
   vector[Nobs] t;
 
   // Study number for each observation
-  int<lower=1> st[Nobs];
+  array[Nobs] int<lower=1> st;
 
   // link function (1=normal, 2=binary, 3=poisson)
   int<lower=1,upper=3> link;
@@ -23,12 +23,12 @@ data {
   vector[Nobs] y_se;
 
   // binomial data, link=logit=2
-  int<lower=0>  r[Nobs];
-  int<lower=1>  n[Nobs];
+  array[Nobs] int<lower=0>  r;
+  array[Nobs] int<lower=1>  n;
 
 
   // count data, link=log=3
-  int<lower=0> count[Nobs];
+  array[Nobs] int<lower=0> count;
   vector[Nobs]    exposure;
 
   // Priors
@@ -58,9 +58,9 @@ data {
 parameters {
   vector[Nobs] mu;                             // baseline risks (log odds)
   real theta;                               // relative treatment effect (log odds ratio)
-  vector[Nobs] u[re];                          // individual treatment effects
-  real<lower=0> tau[re];                        // heterogeneity stdev.
-  vector[ncov] beta[mreg];                      // beta coeffients in meta-regression
+  array[re] vector[Nobs] u;                          // individual treatment effects
+  array[re] real<lower=0> tau;                        // heterogeneity stdev.
+  array[mreg] vector[ncov] beta;                      // beta coeffients in meta-regression
 }
 
 transformed parameters {
@@ -159,7 +159,7 @@ model {
 
 generated quantities {
   vector[Nobs] log_lik;                // pointwise log-likelihood contribution
-  real theta_pred[re];                 // predicted log-odds ratio for the new study
+  array[re] real theta_pred;                 // predicted log-odds ratio for the new study
 
 
   for (s in 1:Nobs) {

--- a/inst/stan/SMA_Higgins.stan
+++ b/inst/stan/SMA_Higgins.stan
@@ -13,7 +13,7 @@ data {
   vector[Nobs] t;
 
   // Study number for each observation
-  int<lower=1> st[Nobs];
+  array[Nobs] int<lower=1> st;
 
   // link function (1=normal, 2=binary, 3=poisson)
   int<lower=1,upper=3> link;
@@ -23,12 +23,12 @@ data {
   vector[Nobs] y_se;
 
   // binomial data, link=logit=2
-  int<lower=0>  r[Nobs];
-  int<lower=1>  n[Nobs];
+  array[Nobs] int<lower=0>  r;
+  array[Nobs] int<lower=1>  n;
 
 
   // count data, link=log=3
-  int<lower=0> count[Nobs];
+  array[Nobs] int<lower=0> count;
   vector[Nobs]    exposure;
 
   // Priors
@@ -58,9 +58,9 @@ data {
 parameters {
   vector[Nobs] mu;                             // baseline risks (log odds)
   real theta;                               // relative treatment effect (log odds ratio)
-  vector[Nobs] u[re];                          // individual treatment effects
-  real<lower=0> tau[re];                        // heterogeneity stdev.
-  vector[ncov] beta[mreg];                      // beta coeffients in meta-regression
+  array[re] vector[Nobs] u;                          // individual treatment effects
+  array[re] real<lower=0> tau;                        // heterogeneity stdev.
+  array[mreg] vector[ncov] beta;                      // beta coeffients in meta-regression
 }
 
 transformed parameters {
@@ -159,7 +159,7 @@ model {
 
 generated quantities {
   vector[Nobs] log_lik;                // pointwise log-likelihood contribution
-  real theta_pred[re];                 // predicted log-odds ratio for the new study
+  array[re] real theta_pred;                 // predicted log-odds ratio for the new study
 
 
   for (s in 1:Nobs) {


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
