### PR TITLE
Add tranformations to allow for RR and RD

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ LinkingTo: StanHeaders (>= 2.18.0), rstan (>= 2.18.1), BH (>= 1.66.0-1),
           Rcpp (>= 0.12.17), RcppEigen (>= 0.3.3.4.0), RcppParallel (>= 5.0.1),
 SystemRequirements: GNU make
 NeedsCompilation: yes
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.3
 URL: https://github.com/gunhanb/MetaStan
 BugReports: https://github.com/gunhanb/MetaStan/issues
 VignetteBuilder: knitr

--- a/R/meta_stan.R
+++ b/R/meta_stan.R
@@ -27,6 +27,8 @@
 #' model (Simmonds and Higgins, 2014).
 #' @param likelihood A string specifying the likelihood function defining the statistical
 #' model. Options include  `normal`, `binomial`, and `Poisson`.
+#' @param transformation A string specifying the type of transformation used for
+#' binomaial likelihood. Options include `none` (default), `relative_risk`, and `risk_difference`.
 #' @param re A string specifying whether random-effects are included to the model. When `FALSE`, the
 #' model corresponds to a fixed-effects model. The default is `TRUE`.
 #' @param ncp A string specifying whether to use a non-centered parametrization.
@@ -97,6 +99,7 @@
 #'
 meta_stan = function(data = NULL,
                      likelihood = NULL,
+                     transformation = "none",
                      mu_prior = c(0, 10),
                      theta_prior = NULL,
                      tau_prior = 0.5,
@@ -123,6 +126,18 @@ meta_stan = function(data = NULL,
     stop("Function argument \"likelihood\" must be equal to \"binomial\" or \"normal\" or \"poisson\"!!!")
   }
 
+  ################ check transformation used
+  if (likelihood == "binomial") {
+    if (transformation %in% c("none", "relative_risk", "risk_difference") == FALSE) {
+      stop("Function argument \"transformation\" must be equal to \"none\" or \"relative_risk\" or \"risk_difference\"!!!")
+    } else if (transformation != "none") {
+      stop("\"transformation\" is only valid for \"binomial\" likelihood !!!")
+    }
+  }
+
+  if (transformation != "none" && param != "Smith"){
+    stop("\"transformation\" is only valid for \"Smith\" parameterization !!!")
+  }
 
   ################ check prior for treatment effect parameter
   if(is.null(delta) == TRUE & is.null(theta_prior) == TRUE){
@@ -155,6 +170,8 @@ meta_stan = function(data = NULL,
   if(likelihood == "normal")   { link = 1 }
   if(likelihood == "binomial") { link = 2 }
   if(likelihood == "poisson")  { link = 3 }
+  if(likelihood == "binomial" && transformation == "relative_risk")  { link = 4 }
+  if(likelihood == "binomial" && transformation == "risk_difference")  { link = 5 }
 
 
   ################ check data

--- a/inst/stan/SMA.stan
+++ b/inst/stan/SMA.stan
@@ -15,8 +15,13 @@ data {
   // Study number for each observation
   int<lower=1> st[Nobs];
 
-  // link function (1=normal, 2=binary, 3=poisson)
-  int<lower=1,upper=3> link;
+  // link function
+  // 1 = continuous (MD or SMD)
+  // 2 = binary logit (log OR)
+  // 3 = count log (rate ratio)
+  // 4 = binary log (log RR)
+  // 5 = binary identity (RD)
+  int<lower=1,upper=5> link;
 
   // normal data, link=identity=1
   vector[Nobs] y;
@@ -67,6 +72,23 @@ transformed parameters {
   vector[Nobs] d;
   vector[max(st)] temp;
   vector[max(st)] beta_cov;
+
+  vector[Nobs] p; // event probabilities
+
+  for (i in 1:Nobs) {
+    if (link == 2) {
+      // logit link (OR)
+      p[i] = inv_logit(d[i]);
+    }
+    if (link == 4) {
+      // log link (RR)
+      p[i] = exp(d[i]);
+    }
+      if (link == 5) {
+      // identity link (RD)
+      p[i] = d[i];
+    }
+  }
 
   if(mreg) {
     for(i in 1:Nobs)
@@ -150,10 +172,43 @@ model {
 
   if(mreg)  beta[1] ~ normal(beta_prior[1], beta_prior[2]);
 
+  if (link == 4) {
+    // RR: probabilities must be <= 1
+    p ~ uniform(0, 1);
+  }
+
+  if (link == 5) {
+    // RD: identity link must stay in (0,1)
+    p ~ uniform(0, 1);
+  }
+
   // likelihood
-  if(link == 1) y ~ normal(d, y_se);
-  if(link == 2) r ~ binomial_logit(n, d);
-  if(link == 3) count ~ poisson_log(exposure + d);
+  if (link == 1) {
+    // MD or SMD
+    y ~ normal(d, y_se);
+  }
+
+  if (link == 2) {
+    // logit link (OR)
+    r ~ binomial_logit(n, d);
+  }
+
+  if (link == 3) {
+    // log rate ratio
+    count ~ poisson_log(exposure + d);
+  }
+
+  if (link == 4) {
+    // log link (RR)
+    for (i in 1:Nobs)
+      r[i] ~ binomial(n[i], p[i]);
+  }
+
+  if (link == 5) {
+    // identity link (RD)
+    for (i in 1:Nobs)
+      r[i] ~ binomial(n[i], p[i]);
+  }
 
 }
 
@@ -163,9 +218,24 @@ generated quantities {
 
 
   for (s in 1:Nobs) {
-    if(link == 1)  log_lik[s] = normal_lpdf(y[s] | d[s], y_se[s]);
-    if(link == 2)  log_lik[s] = binomial_logit_lpmf(r[s] | n[s], d[s]);
-    if(link == 3)  log_lik[s] = poisson_log_lpmf(count[s] | exposure[s] + d[s]);
+    if (link == 1)
+    log_lik[s] = normal_lpdf(y[s] | d[s], y_se[s]);
+
+
+    if (link == 2)
+    log_lik[s] = binomial_logit_lpmf(r[s] | n[s], d[s]);
+
+
+    if (link == 3)
+    log_lik[s] = poisson_log_lpmf(count[s] | exposure[s] + d[s]);
+
+
+    if (link == 4)
+    log_lik[s] = binomial_lpmf(r[s] | n[s], p[s]);
+
+
+    if (link == 5)
+    log_lik[s] = binomial_lpmf(r[s] | n[s], p[s]);
   }
 
   // Prediction for new study

--- a/man/MetaStan-package.Rd
+++ b/man/MetaStan-package.Rd
@@ -29,6 +29,14 @@ http://mc-stan.org
 Günhan, B and Röver, C and Friede, T (2020). Random-effects meta-analysis of few studies
 involving rare events. Research Synthesis Methods. doi = 10.1002/jrsm.1370.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/gunhanb/MetaStan}
+  \item Report bugs at \url{https://github.com/gunhanb/MetaStan/issues}
+}
+
+}
 \author{
 Burak Kuersad Guenhan <burak.gunhan@med.uni-goettingen.de>
 }

--- a/man/meta_stan.Rd
+++ b/man/meta_stan.Rd
@@ -7,6 +7,7 @@
 meta_stan(
   data = NULL,
   likelihood = NULL,
+  transformation = "none",
   mu_prior = c(0, 10),
   theta_prior = NULL,
   tau_prior = 0.5,
@@ -31,6 +32,9 @@ meta_stan(
 
 \item{likelihood}{A string specifying the likelihood function defining the statistical
 model. Options include  `normal`, `binomial`, and `Poisson`.}
+
+\item{transformation}{A string specifying the type of transformation used for
+binomaial likelihood. Options include `none` (default), `relative_risk`, and `risk_difference`.}
 
 \item{mu_prior}{A numerical vector specifying the parameter of the normal prior
 density for baseline risks, first value is parameter for mean, second is for variance.

--- a/man/metastan_data.Rd
+++ b/man/metastan_data.Rd
@@ -17,8 +17,7 @@ metastan_data(
   exposure,
   labels,
   data,
-  sort = TRUE,
-  checkForConflicts = TRUE
+  sort = TRUE
 )
 }
 \arguments{


### PR DESCRIPTION
Adds a parameter to meta_stan and updates the stan code, to allow the Smith model to use risk ratio and risk difference.